### PR TITLE
Fix TOTP capitalization in login comment

### DIFF
--- a/backend/google_auth.py
+++ b/backend/google_auth.py
@@ -185,7 +185,7 @@ def login(p: Login, db: Session = Depends(get_db)):
     if not u.is_active:
         raise HTTPException(403, "Account disabled")
 
-    # If 2FA enabled, require TOTp code
+    # If 2FA enabled, require TOTP code
     if u.totp_enabled:
         if not p.code or not verify_totp(u.totp_secret, p.code):
             raise HTTPException(401, "Invalid 2FA code")


### PR DESCRIPTION
## Summary
- correct TOTP acronym capitalization in login comment

## Testing
- not run (comment-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69414bd674f883249c039e6fcde1e0c8)