### PR TITLE
Add GFPS Tauri desktop scaffold

### DIFF
--- a/GFPS/desktop/index.html
+++ b/GFPS/desktop/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GFPS — Global Football Probability System</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/GFPS/desktop/package.json
+++ b/GFPS/desktop/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "gfps-desktop",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0",
+    "chart.js": "^4.4.3",
+    "clsx": "^2.1.0",
+    "react": "^18.3.1",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^2.0.0",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11"
+  }
+}

--- a/GFPS/desktop/src-tauri/Cargo.toml
+++ b/GFPS/desktop/src-tauri/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "gfps-desktop"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "2.0.0", features = [] }
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tauri = { version = "2.0.0", features = ["macros"] }
+
+[profile.release]
+opt-level = 3

--- a/GFPS/desktop/src-tauri/build.rs
+++ b/GFPS/desktop/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/GFPS/desktop/src-tauri/src/main.rs
+++ b/GFPS/desktop/src-tauri/src/main.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    tauri::Builder::default()
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/GFPS/desktop/src/api/client.ts
+++ b/GFPS/desktop/src/api/client.ts
@@ -1,0 +1,42 @@
+import { useSettingsStore } from '@store/settings';
+import { Fixture, LiveOddsRow, ModelInfo, Prediction, ValueBet } from './types';
+
+const jsonHeaders = { 'Content-Type': 'application/json' };
+
+const buildUrl = (path: string) => {
+  const baseUrl = useSettingsStore.getState().apiUrl.replace(/\/$/, '');
+  return `${baseUrl}${path}`;
+};
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetch(buildUrl(path));
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json();
+}
+
+async function post<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(buildUrl(path), {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json();
+}
+
+export const api = {
+  fixtures: () => get<Fixture[]>('/fixtures'),
+  liveOdds: () => get<LiveOddsRow[]>('/live-odds'),
+  predictions: () => get<Prediction[]>('/predictions'),
+  valueBets: () => get<ValueBet[]>('/value-bets'),
+  trainModel: () => post<{ message: string }>('/ml/train'),
+  models: () => get<ModelInfo[]>('/ml/models'),
+  activateModel: (version: string) => post<{ message: string }>(`/ml/activate/${version}`)
+};
+
+export const websocketUrl = () => {
+  const apiUrl = useSettingsStore.getState().apiUrl;
+  const host = apiUrl.replace('http://', '').replace('https://', '');
+  const protocol = apiUrl.startsWith('https') ? 'wss' : 'ws';
+  return `${protocol}://${host}/ws/live-matches`;
+};

--- a/GFPS/desktop/src/api/types.ts
+++ b/GFPS/desktop/src/api/types.ts
@@ -1,0 +1,49 @@
+export interface Fixture {
+  id: string;
+  homeTeam: string;
+  awayTeam: string;
+  league: string;
+  startTime: string;
+  status: 'scheduled' | 'live' | 'finished';
+  timer?: string;
+  score?: {
+    home: number;
+    away: number;
+  };
+}
+
+export interface LiveOddsRow {
+  market: string;
+  home: number;
+  draw: number;
+  away: number;
+  source?: string;
+}
+
+export interface Prediction {
+  fixtureId: string;
+  homeWinProbability: number;
+  drawProbability: number;
+  awayWinProbability: number;
+}
+
+export interface ValueBet {
+  match: string;
+  market: string;
+  odds: number;
+  modelProbability: number;
+  expectedValue: number;
+}
+
+export interface ModelInfo {
+  version: string;
+  roi: number;
+  logLoss: number;
+  status: 'active' | 'ready' | 'training';
+}
+
+export interface MatchEvent {
+  minute: number;
+  description: string;
+  type: 'goal' | 'card' | 'substitution' | 'info';
+}

--- a/GFPS/desktop/src/app/App.tsx
+++ b/GFPS/desktop/src/app/App.tsx
@@ -1,0 +1,29 @@
+import { Sidebar } from '@components/Sidebar';
+import { TopBar } from '@components/TopBar';
+import { useNavigationStore } from '@store/navigation';
+import { Dashboard } from '@screens/Dashboard';
+import { LiveMatchCenter } from '@screens/LiveMatchCenter';
+import { ValueBets } from '@screens/ValueBets';
+import { ModelsTraining } from '@screens/ModelsTraining';
+import { Settings } from '@screens/Settings';
+import { palette } from '@theme/palette';
+
+export const App = () => {
+  const { section } = useNavigationStore();
+
+  return (
+    <div style={{ display: 'flex', height: '100vh', background: palette.background }}>
+      <Sidebar />
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <TopBar />
+        <main style={{ padding: 20, overflow: 'auto', flex: 1 }}>
+          {section === 'Dashboard' && <Dashboard />}
+          {section === 'Live Match Center' && <LiveMatchCenter />}
+          {section === 'Value Bets (EV+)' && <ValueBets />}
+          {section === 'Models & Training' && <ModelsTraining />}
+          {section === 'Settings' && <Settings />}
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/GFPS/desktop/src/app/global.css
+++ b/GFPS/desktop/src/app/global.css
@@ -1,0 +1,43 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: dark;
+  background-color: #060712;
+  color: #e5e7eb;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  background: radial-gradient(circle at 20% 20%, rgba(32, 95, 151, 0.12), transparent 25%),
+    radial-gradient(circle at 80% 0%, rgba(0, 220, 130, 0.08), transparent 25%),
+    #060712;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, #1f9ae5, #0fd7a1);
+  border-radius: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.05);
+}

--- a/GFPS/desktop/src/charts/MomentumChart.tsx
+++ b/GFPS/desktop/src/charts/MomentumChart.tsx
@@ -1,0 +1,42 @@
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Filler
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler);
+
+export const MomentumChart = () => {
+  const labels = Array.from({ length: 15 }).map((_, idx) => `${idx * 6}'`);
+  const data = labels.map((_, idx) => Math.sin(idx / 3) * 30 + 50);
+
+  return (
+    <Line
+      data={{
+        labels,
+        datasets: [
+          {
+            label: 'Momentum',
+            data,
+            borderColor: '#1f9ae5',
+            backgroundColor: 'rgba(31,154,229,0.12)',
+            fill: true,
+            tension: 0.4
+          }
+        ]
+      }}
+      options={{
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { ticks: { color: '#9ca3af' }, grid: { color: 'rgba(255,255,255,0.05)' } },
+          y: { ticks: { color: '#9ca3af' }, grid: { color: 'rgba(255,255,255,0.05)' } }
+        }
+      }}
+    />
+  );
+};

--- a/GFPS/desktop/src/charts/ProbabilityEvolutionChart.tsx
+++ b/GFPS/desktop/src/charts/ProbabilityEvolutionChart.tsx
@@ -1,0 +1,55 @@
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+export const ProbabilityEvolutionChart = () => {
+  const labels = Array.from({ length: 10 }).map((_, idx) => `${idx * 10}'`);
+  const random = () => labels.map(() => Math.max(5, Math.min(90, 40 + Math.random() * 20)));
+
+  return (
+    <Line
+      data={{
+        labels,
+        datasets: [
+          {
+            label: 'Home',
+            data: random(),
+            borderColor: '#0fd7a1',
+            backgroundColor: 'rgba(15,215,161,0.18)',
+            tension: 0.3
+          },
+          {
+            label: 'Draw',
+            data: random(),
+            borderColor: '#f59e0b',
+            backgroundColor: 'rgba(245,158,11,0.14)',
+            tension: 0.3
+          },
+          {
+            label: 'Away',
+            data: random(),
+            borderColor: '#1f9ae5',
+            backgroundColor: 'rgba(31,154,229,0.18)',
+            tension: 0.3
+          }
+        ]
+      }}
+      options={{
+        plugins: { legend: { labels: { color: '#e5e7eb' } } },
+        scales: {
+          x: { ticks: { color: '#9ca3af' }, grid: { color: 'rgba(255,255,255,0.05)' } },
+          y: { ticks: { color: '#9ca3af' }, grid: { color: 'rgba(255,255,255,0.05)' }, min: 0, max: 100 }
+        }
+      }}
+    />
+  );
+};

--- a/GFPS/desktop/src/components/DataTable.tsx
+++ b/GFPS/desktop/src/components/DataTable.tsx
@@ -1,0 +1,58 @@
+import { palette } from '@theme/palette';
+import React from 'react';
+
+interface Column<T> {
+  key: keyof T | string;
+  header: string;
+  render?: (row: T) => React.ReactNode;
+}
+
+interface Props<T> {
+  columns: Column<T>[];
+  data: T[];
+}
+
+export function DataTable<T extends Record<string, any>>({ columns, data }: Props<T>) {
+  return (
+    <div
+      style={{
+        border: `1px solid ${palette.border}`,
+        borderRadius: 12,
+        overflow: 'hidden',
+        background: palette.card
+      }}
+    >
+      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead style={{ background: 'rgba(255,255,255,0.03)' }}>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col.header}
+                style={{
+                  textAlign: 'left',
+                  padding: '12px 14px',
+                  color: palette.textSecondary,
+                  fontWeight: 500,
+                  borderBottom: `1px solid ${palette.border}`
+                }}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row, idx) => (
+            <tr key={idx} style={{ borderBottom: `1px solid ${palette.border}` }}>
+              {columns.map((col) => (
+                <td key={col.header} style={{ padding: '12px 14px', color: palette.textPrimary }}>
+                  {col.render ? col.render(row) : (row[col.key as keyof T] as React.ReactNode)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/GFPS/desktop/src/components/KpiCard.tsx
+++ b/GFPS/desktop/src/components/KpiCard.tsx
@@ -1,0 +1,26 @@
+import { palette } from '@theme/palette';
+
+interface Props {
+  label: string;
+  value: string;
+  subLabel?: string;
+}
+
+export const KpiCard = ({ label, value, subLabel }: Props) => {
+  return (
+    <div
+      style={{
+        background: `linear-gradient(160deg, rgba(31,154,229,0.15), rgba(15,215,161,0.12))`,
+        border: `1px solid ${palette.border}`,
+        borderRadius: 14,
+        padding: 16,
+        minWidth: 180,
+        boxShadow: '0 10px 40px rgba(0,0,0,0.35)'
+      }}
+    >
+      <div style={{ color: palette.textSecondary, fontSize: 13, marginBottom: 8 }}>{label}</div>
+      <div style={{ color: palette.textPrimary, fontSize: 28, fontWeight: 700 }}>{value}</div>
+      {subLabel && <div style={{ color: palette.textSecondary, marginTop: 6 }}>{subLabel}</div>}
+    </div>
+  );
+};

--- a/GFPS/desktop/src/components/Sidebar.tsx
+++ b/GFPS/desktop/src/components/Sidebar.tsx
@@ -1,0 +1,63 @@
+import { useNavigationStore, Section } from '@store/navigation';
+import { palette } from '@theme/palette';
+import clsx from 'clsx';
+
+const items: { label: Section; icon: string }[] = [
+  { label: 'Dashboard', icon: '📊' },
+  { label: 'Live Match Center', icon: '📡' },
+  { label: 'Value Bets (EV+)', icon: '💹' },
+  { label: 'Models & Training', icon: '🧠' },
+  { label: 'Settings', icon: '⚙️' }
+];
+
+export const Sidebar = () => {
+  const { section, setSection } = useNavigationStore();
+
+  return (
+    <aside
+      style={{
+        width: 240,
+        background: palette.card,
+        borderRight: `1px solid ${palette.border}`,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: '20px 16px',
+        gap: 8
+      }}
+    >
+      <div style={{ color: palette.textSecondary, fontSize: 12, letterSpacing: 1 }}>GFPS DESKTOP</div>
+      <div style={{ color: palette.textPrimary, fontSize: 18, fontWeight: 700, marginBottom: 16 }}>
+        Global Football Probability System
+      </div>
+      <nav style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {items.map(({ label, icon }) => (
+          <button
+            key={label}
+            onClick={() => setSection(label)}
+            className={clsx('nav-item', { active: section === label })}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              padding: '12px 14px',
+              borderRadius: 10,
+              border: `1px solid ${palette.border}`,
+              background:
+                section === label
+                  ? `linear-gradient(90deg, rgba(31,154,229,0.25), rgba(15,215,161,0.18))`
+                  : palette.card,
+              color: palette.textPrimary,
+              cursor: 'pointer'
+            }}
+          >
+            <span style={{ fontSize: 18 }}>{icon}</span>
+            <span style={{ fontWeight: 600 }}>{label}</span>
+          </button>
+        ))}
+      </nav>
+      <div style={{ marginTop: 'auto', fontSize: 12, color: palette.textSecondary }}>
+        Desktop-only • Connected to FastAPI backend
+      </div>
+    </aside>
+  );
+};

--- a/GFPS/desktop/src/components/TopBar.tsx
+++ b/GFPS/desktop/src/components/TopBar.tsx
@@ -1,0 +1,35 @@
+import { palette } from '@theme/palette';
+import { useSettingsStore } from '@store/settings';
+
+export const TopBar = () => {
+  const { apiUrl } = useSettingsStore();
+  const now = new Date();
+  return (
+    <header
+      style={{
+        height: 64,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 20px',
+        borderBottom: `1px solid ${palette.border}`,
+        background: 'rgba(17,24,39,0.6)',
+        backdropFilter: 'blur(10px)'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: '50%',
+            background: '#22c55e',
+            boxShadow: '0 0 10px #22c55e'
+          }}
+        />
+        <div style={{ color: palette.textPrimary, fontWeight: 600 }}>Live link: {apiUrl}</div>
+      </div>
+      <div style={{ color: palette.textSecondary, fontSize: 14 }}>{now.toUTCString()}</div>
+    </header>
+  );
+};

--- a/GFPS/desktop/src/hooks/useLiveMatches.ts
+++ b/GFPS/desktop/src/hooks/useLiveMatches.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { websocketUrl } from '@api/client';
+import { Fixture, MatchEvent } from '@api/types';
+
+interface LiveMatchState {
+  fixtures: Fixture[];
+  events: Record<string, MatchEvent[]>;
+}
+
+export const useLiveMatches = () => {
+  const [state, setState] = useState<LiveMatchState>({ fixtures: [], events: {} });
+
+  useEffect(() => {
+    const socket = new WebSocket(websocketUrl());
+
+    socket.onmessage = (event) => {
+      const payload = JSON.parse(event.data);
+      if (payload.type === 'fixtures') {
+        setState((prev) => ({ ...prev, fixtures: payload.data as Fixture[] }));
+      }
+      if (payload.type === 'event') {
+        const { fixtureId, event: matchEvent } = payload.data as {
+          fixtureId: string;
+          event: MatchEvent;
+        };
+        setState((prev) => ({
+          fixtures: prev.fixtures,
+          events: {
+            ...prev.events,
+            [fixtureId]: [...(prev.events[fixtureId] || []), matchEvent]
+          }
+        }));
+      }
+    };
+
+    return () => socket.close();
+  }, []);
+
+  return state;
+};

--- a/GFPS/desktop/src/hooks/useQuery.ts
+++ b/GFPS/desktop/src/hooks/useQuery.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+interface QueryState<T> {
+  data?: T;
+  loading: boolean;
+  error?: string;
+}
+
+export const useQuery = <T,>(fn: () => Promise<T>, deps: unknown[] = []): QueryState<T> => {
+  const [state, setState] = useState<QueryState<T>>({ loading: true });
+
+  useEffect(() => {
+    let active = true;
+    setState({ loading: true });
+
+    fn()
+      .then((data) => {
+        if (active) setState({ loading: false, data });
+      })
+      .catch((error) => {
+        if (active) setState({ loading: false, error: error.message });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, deps);
+
+  return state;
+};

--- a/GFPS/desktop/src/main.tsx
+++ b/GFPS/desktop/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from '@app/App';
+import '@app/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/GFPS/desktop/src/screens/Dashboard.tsx
+++ b/GFPS/desktop/src/screens/Dashboard.tsx
@@ -1,0 +1,60 @@
+import { api } from '@api/client';
+import { useQuery } from '@hooks/useQuery';
+import { KpiCard } from '@components/KpiCard';
+import { DataTable } from '@components/DataTable';
+import { palette } from '@theme/palette';
+import { ValueBet } from '@api/types';
+
+export const Dashboard = () => {
+  const fixtures = useQuery(api.fixtures, []);
+  const valueBets = useQuery(api.valueBets, []);
+
+  const activeMatches = fixtures.data?.filter((f) => f.status === 'live').length ?? 0;
+  const scheduled = fixtures.data?.filter((f) => f.status === 'scheduled').length ?? 0;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 14 }}>
+        <KpiCard label="Live Matches" value={activeMatches.toString()} subLabel="Currently trading" />
+        <KpiCard label="Upcoming" value={scheduled.toString()} subLabel="Within next 24h" />
+        <KpiCard label="Active Models" value="3" subLabel="production + variants" />
+        <KpiCard label="EV+ signals" value={(valueBets.data?.length ?? 0).toString()} subLabel="Today" />
+      </div>
+
+      <section
+        style={{
+          border: `1px solid ${palette.border}`,
+          borderRadius: 14,
+          padding: 16,
+          background: palette.cardElevated,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <div style={{ color: palette.textPrimary, fontWeight: 700, fontSize: 18 }}>Top EV+ Opportunities</div>
+          <div style={{ color: palette.textSecondary, fontSize: 13 }}>Live feed from FastAPI</div>
+        </div>
+        <DataTable<ValueBet>
+          columns={[
+            { header: 'Match', key: 'match' },
+            { header: 'Market', key: 'market' },
+            { header: 'Odds', key: 'odds', render: (row) => row.odds.toFixed(2) },
+            {
+              header: 'Model Probability',
+              key: 'modelProbability',
+              render: (row) => `${(row.modelProbability * 100).toFixed(1)}%`
+            },
+            {
+              header: 'EV%',
+              key: 'expectedValue',
+              render: (row) => `${(row.expectedValue * 100).toFixed(1)}%`
+            }
+          ]}
+          data={valueBets.data ?? []}
+        />
+      </section>
+    </div>
+  );
+};

--- a/GFPS/desktop/src/screens/LiveMatchCenter.tsx
+++ b/GFPS/desktop/src/screens/LiveMatchCenter.tsx
@@ -1,0 +1,232 @@
+import { api } from '@api/client';
+import { MomentumChart } from '@charts/MomentumChart';
+import { ProbabilityEvolutionChart } from '@charts/ProbabilityEvolutionChart';
+import { DataTable } from '@components/DataTable';
+import { useQuery } from '@hooks/useQuery';
+import { useLiveMatches } from '@hooks/useLiveMatches';
+import { palette } from '@theme/palette';
+import { ReactNode, useState } from 'react';
+import { Fixture, LiveOddsRow, Prediction } from '@api/types';
+
+export const LiveMatchCenter = () => {
+  const { fixtures: liveFixtures, events } = useLiveMatches();
+  const fixturesQuery = useQuery(api.fixtures, []);
+  const oddsQuery = useQuery(api.liveOdds, []);
+  const predictionsQuery = useQuery(api.predictions, []);
+  const [selected, setSelected] = useState<Fixture | null>(null);
+
+  const fixtures = liveFixtures.length ? liveFixtures : fixturesQuery.data ?? [];
+  const liveOdds = oddsQuery.data ?? [];
+  const predictions = predictionsQuery.data ?? [];
+
+  const selectedPrediction: Prediction | undefined = predictions.find((p) => p.fixtureId === selected?.id);
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '360px 1fr', gap: 16, height: '100%' }}>
+      <section style={{ border: `1px solid ${palette.border}`, borderRadius: 14, overflow: 'hidden' }}>
+        <div style={{ padding: 14, borderBottom: `1px solid ${palette.border}`, background: 'rgba(17,24,39,0.7)' }}>
+          <div style={{ color: palette.textPrimary, fontWeight: 700 }}>Live Matches</div>
+          <div style={{ color: palette.textSecondary, fontSize: 13 }}>Click a row to open detail</div>
+        </div>
+        <div style={{ maxHeight: 'calc(100vh - 220px)', overflow: 'auto' }}>
+          <DataTable<Fixture>
+            columns={[
+              {
+                header: 'Match',
+                key: 'homeTeam',
+                render: (row) => (
+                  <button
+                    onClick={() => setSelected(row)}
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      width: '100%',
+                      textAlign: 'left',
+                      background: 'transparent',
+                      border: 'none',
+                      color: palette.textPrimary,
+                      cursor: 'pointer'
+                    }}
+                  >
+                    <span style={{ fontWeight: 600 }}>
+                      {row.homeTeam} vs {row.awayTeam}
+                    </span>
+                    <span style={{ color: palette.textSecondary, fontSize: 12 }}>{row.league}</span>
+                  </button>
+                )
+              },
+              {
+                header: 'Status',
+                key: 'status',
+                render: (row) => <span style={{ color: '#22c55e' }}>{row.status}</span>
+              },
+              {
+                header: 'Score',
+                key: 'score',
+                render: (row) =>
+                  row.score ? `${row.score.home} - ${row.score.away}` : row.timer || row.startTime
+              }
+            ]}
+            data={fixtures}
+          />
+        </div>
+      </section>
+
+      <section
+        style={{
+          border: `1px solid ${palette.border}`,
+          borderRadius: 14,
+          background: palette.cardElevated,
+          padding: 16,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12
+        }}
+      >
+        {selected ? (
+          <>
+            <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <div>
+                <div style={{ color: palette.textPrimary, fontSize: 20, fontWeight: 700 }}>
+                  {selected.homeTeam} vs {selected.awayTeam}
+                </div>
+                <div style={{ color: palette.textSecondary }}>
+                  {selected.league} • {selected.timer || selected.startTime}
+                </div>
+              </div>
+              <div
+                style={{
+                  background: 'rgba(31,154,229,0.12)',
+                  padding: '8px 12px',
+                  borderRadius: 10,
+                  border: `1px solid ${palette.border}`,
+                  color: palette.textPrimary
+                }}
+              >
+                Live Score: {selected.score ? `${selected.score.home} - ${selected.score.away}` : 'N/A'}
+              </div>
+            </header>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: 12 }}>
+              <div
+                style={{
+                  border: `1px solid ${palette.border}`,
+                  borderRadius: 12,
+                  padding: 12,
+                  background: palette.card
+                }}
+              >
+                <div style={{ color: palette.textPrimary, fontWeight: 600, marginBottom: 8 }}>Live Odds (1X2)</div>
+                <DataTable<LiveOddsRow>
+                  columns={[
+                    { header: 'Market', key: 'market' },
+                    { header: 'Home', key: 'home', render: (row) => row.home.toFixed(2) },
+                    { header: 'Draw', key: 'draw', render: (row) => row.draw.toFixed(2) },
+                    { header: 'Away', key: 'away', render: (row) => row.away.toFixed(2) },
+                    { header: 'Source', key: 'source' }
+                  ]}
+                  data={liveOdds}
+                />
+              </div>
+
+              <div
+                style={{
+                  border: `1px solid ${palette.border}`,
+                  borderRadius: 12,
+                  padding: 12,
+                  background: palette.card
+                }}
+              >
+                <div style={{ color: palette.textPrimary, fontWeight: 600, marginBottom: 8 }}>AI Probabilities</div>
+                {selectedPrediction ? (
+                  <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
+                    <ProbabilityPill label="Home" value={selectedPrediction.homeWinProbability} color="#0fd7a1" />
+                    <ProbabilityPill label="Draw" value={selectedPrediction.drawProbability} color="#f59e0b" />
+                    <ProbabilityPill label="Away" value={selectedPrediction.awayWinProbability} color="#1f9ae5" />
+                  </div>
+                ) : (
+                  <div style={{ color: palette.textSecondary }}>No prediction data available.</div>
+                )}
+              </div>
+            </div>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+              <ChartCard title="Momentum" subtitle="Live dominance trajectory">
+                <MomentumChart />
+              </ChartCard>
+              <ChartCard title="Probability Evolution" subtitle="Win/Draw/Away over time">
+                <ProbabilityEvolutionChart />
+              </ChartCard>
+            </div>
+
+            <div
+              style={{
+                border: `1px solid ${palette.border}`,
+                borderRadius: 12,
+                padding: 12,
+                background: palette.card
+              }}
+            >
+              <div style={{ color: palette.textPrimary, fontWeight: 600, marginBottom: 8 }}>Match Events</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {(events[selected.id] || []).map((event, idx) => (
+                  <div
+                    key={`${event.minute}-${idx}`}
+                    style={{ display: 'flex', gap: 12, color: palette.textPrimary }}
+                  >
+                    <div style={{ color: palette.textSecondary, width: 40 }}>{event.minute}'</div>
+                    <div>{event.description}</div>
+                  </div>
+                ))}
+                {(events[selected.id] || []).length === 0 && (
+                  <div style={{ color: palette.textSecondary }}>No live events yet.</div>
+                )}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: palette.textSecondary,
+              height: '100%'
+            }}
+          >
+            Select a match to view live analytics.
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+const ProbabilityPill = ({ label, value, color }: { label: string; value: number; color: string }) => (
+  <div
+    style={{
+      border: `1px solid ${palette.border}`,
+      borderRadius: 12,
+      padding: 12,
+      background: 'rgba(255,255,255,0.02)'
+    }}
+  >
+    <div style={{ color: palette.textSecondary, fontSize: 13 }}>{label}</div>
+    <div style={{ color, fontSize: 22, fontWeight: 700 }}>{(value * 100).toFixed(1)}%</div>
+  </div>
+);
+
+const ChartCard = ({ title, subtitle, children }: { title: string; subtitle: string; children: ReactNode }) => (
+  <div
+    style={{
+      border: `1px solid ${palette.border}`,
+      borderRadius: 12,
+      padding: 12,
+      background: palette.card
+    }}
+  >
+    <div style={{ color: palette.textPrimary, fontWeight: 600 }}>{title}</div>
+    <div style={{ color: palette.textSecondary, fontSize: 13, marginBottom: 8 }}>{subtitle}</div>
+    {children}
+  </div>
+);

--- a/GFPS/desktop/src/screens/ModelsTraining.tsx
+++ b/GFPS/desktop/src/screens/ModelsTraining.tsx
@@ -1,0 +1,93 @@
+import { api } from '@api/client';
+import { DataTable } from '@components/DataTable';
+import { useQuery } from '@hooks/useQuery';
+import { palette } from '@theme/palette';
+import { ModelInfo } from '@api/types';
+
+export const ModelsTraining = () => {
+  const models = useQuery(api.models, []);
+
+  const handleTrain = async () => {
+    try {
+      await api.trainModel();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleActivate = async (version: string) => {
+    try {
+      await api.activateModel(version);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <section
+      style={{
+        border: `1px solid ${palette.border}`,
+        borderRadius: 14,
+        background: palette.cardElevated,
+        padding: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ color: palette.textPrimary, fontSize: 20, fontWeight: 700 }}>Models & Training</div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            onClick={handleTrain}
+            style={{
+              background: 'linear-gradient(90deg, #1f9ae5, #0fd7a1)',
+              color: '#0b0f1a',
+              border: 'none',
+              padding: '10px 14px',
+              borderRadius: 10,
+              fontWeight: 700,
+              cursor: 'pointer'
+            }}
+          >
+            Train new model
+          </button>
+        </div>
+      </div>
+      <DataTable<ModelInfo>
+        columns={[
+          { header: 'Version', key: 'version' },
+          { header: 'ROI', key: 'roi', render: (row) => `${(row.roi * 100).toFixed(2)}%` },
+          { header: 'LogLoss', key: 'logLoss', render: (row) => row.logLoss.toFixed(3) },
+          {
+            header: 'Status',
+            key: 'status',
+            render: (row) => (
+              <span style={{ color: row.status === 'active' ? '#22c55e' : palette.textSecondary }}>{row.status}</span>
+            )
+          },
+          {
+            header: 'Actions',
+            key: 'version',
+            render: (row) => (
+              <button
+                onClick={() => handleActivate(row.version)}
+                style={{
+                  background: 'transparent',
+                  border: `1px solid ${palette.border}`,
+                  color: palette.textPrimary,
+                  padding: '8px 12px',
+                  borderRadius: 10,
+                  cursor: 'pointer'
+                }}
+              >
+                Activate
+              </button>
+            )
+          }
+        ]}
+        data={models.data ?? []}
+      />
+    </section>
+  );
+};

--- a/GFPS/desktop/src/screens/Settings.tsx
+++ b/GFPS/desktop/src/screens/Settings.tsx
@@ -1,0 +1,87 @@
+import { useSettingsStore } from '@store/settings';
+import { palette } from '@theme/palette';
+import { useState } from 'react';
+
+export const Settings = () => {
+  const { apiUrl, refreshIntervalMs, setApiUrl, setRefreshInterval } = useSettingsStore();
+  const [urlInput, setUrlInput] = useState(apiUrl);
+  const [refreshInput, setRefreshInput] = useState(refreshIntervalMs);
+
+  return (
+    <section
+      style={{
+        border: `1px solid ${palette.border}`,
+        borderRadius: 14,
+        background: palette.cardElevated,
+        padding: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        maxWidth: 720
+      }}
+    >
+      <div style={{ color: palette.textPrimary, fontSize: 20, fontWeight: 700 }}>Settings</div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <label style={{ color: palette.textSecondary, fontSize: 14 }}>Backend API URL</label>
+        <input
+          value={urlInput}
+          onChange={(e) => setUrlInput(e.target.value)}
+          style={{
+            background: palette.card,
+            border: `1px solid ${palette.border}`,
+            color: palette.textPrimary,
+            padding: '12px 14px',
+            borderRadius: 10
+          }}
+        />
+        <button
+          onClick={() => setApiUrl(urlInput)}
+          style={{
+            alignSelf: 'flex-start',
+            background: 'linear-gradient(90deg, #1f9ae5, #0fd7a1)',
+            color: '#0b0f1a',
+            border: 'none',
+            padding: '10px 14px',
+            borderRadius: 10,
+            fontWeight: 700,
+            cursor: 'pointer'
+          }}
+        >
+          Save API URL
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        <label style={{ color: palette.textSecondary, fontSize: 14 }}>Refresh Interval (ms)</label>
+        <input
+          type="number"
+          value={refreshInput}
+          onChange={(e) => setRefreshInput(Number(e.target.value))}
+          style={{
+            background: palette.card,
+            border: `1px solid ${palette.border}`,
+            color: palette.textPrimary,
+            padding: '12px 14px',
+            borderRadius: 10
+          }}
+        />
+        <button
+          onClick={() => setRefreshInterval(refreshInput)}
+          style={{
+            alignSelf: 'flex-start',
+            background: 'transparent',
+            border: `1px solid ${palette.border}`,
+            color: palette.textPrimary,
+            padding: '10px 14px',
+            borderRadius: 10,
+            fontWeight: 700,
+            cursor: 'pointer'
+          }}
+        >
+          Update Interval
+        </button>
+      </div>
+    </section>
+  );
+};

--- a/GFPS/desktop/src/screens/ValueBets.tsx
+++ b/GFPS/desktop/src/screens/ValueBets.tsx
@@ -1,0 +1,42 @@
+import { api } from '@api/client';
+import { DataTable } from '@components/DataTable';
+import { useQuery } from '@hooks/useQuery';
+import { palette } from '@theme/palette';
+import { ValueBet } from '@api/types';
+
+export const ValueBets = () => {
+  const valueBets = useQuery(api.valueBets, []);
+
+  return (
+    <section
+      style={{
+        border: `1px solid ${palette.border}`,
+        borderRadius: 14,
+        background: palette.cardElevated,
+        padding: 16,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ color: palette.textPrimary, fontSize: 20, fontWeight: 700 }}>Value Bets (EV+)</div>
+        <div style={{ color: palette.textSecondary }}>Sortable & filter-ready</div>
+      </div>
+      <DataTable<ValueBet>
+        columns={[
+          { header: 'Match', key: 'match' },
+          { header: 'Market', key: 'market' },
+          { header: 'Odds', key: 'odds', render: (row) => row.odds.toFixed(2) },
+          {
+            header: 'Model Probability',
+            key: 'modelProbability',
+            render: (row) => `${(row.modelProbability * 100).toFixed(1)}%`
+          },
+          { header: 'EV%', key: 'expectedValue', render: (row) => `${(row.expectedValue * 100).toFixed(1)}%` }
+        ]}
+        data={valueBets.data ?? []}
+      />
+    </section>
+  );
+};

--- a/GFPS/desktop/src/store/navigation.ts
+++ b/GFPS/desktop/src/store/navigation.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+export type Section =
+  | 'Dashboard'
+  | 'Live Match Center'
+  | 'Value Bets (EV+)'
+  | 'Models & Training'
+  | 'Settings';
+
+interface NavigationState {
+  section: Section;
+  setSection: (section: Section) => void;
+}
+
+export const useNavigationStore = create<NavigationState>((set) => ({
+  section: 'Dashboard',
+  setSection: (section) => set({ section })
+}));

--- a/GFPS/desktop/src/store/settings.ts
+++ b/GFPS/desktop/src/store/settings.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+export interface SettingsState {
+  apiUrl: string;
+  refreshIntervalMs: number;
+  theme: 'dark';
+  setApiUrl: (apiUrl: string) => void;
+  setRefreshInterval: (ms: number) => void;
+}
+
+export const useSettingsStore = create<SettingsState>((set) => ({
+  apiUrl: 'http://localhost:8000',
+  refreshIntervalMs: 5000,
+  theme: 'dark',
+  setApiUrl: (apiUrl) => set({ apiUrl }),
+  setRefreshInterval: (refreshIntervalMs) => set({ refreshIntervalMs })
+}));

--- a/GFPS/desktop/src/theme/palette.ts
+++ b/GFPS/desktop/src/theme/palette.ts
@@ -1,0 +1,13 @@
+export const palette = {
+  background: '#0b0f1a',
+  card: '#111827',
+  cardElevated: '#152238',
+  textPrimary: '#e5e7eb',
+  textSecondary: '#9ca3af',
+  accent: '#1f9ae5',
+  accentAlt: '#0fd7a1',
+  border: 'rgba(255,255,255,0.08)',
+  success: '#22c55e',
+  warning: '#f59e0b',
+  danger: '#ef4444'
+};

--- a/GFPS/desktop/tauri.conf.json
+++ b/GFPS/desktop/tauri.conf.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "GFPS Desktop",
+  "version": "0.1.0",
+  "identifier": "com.gfps.desktop",
+  "build": {
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build",
+    "frontendDist": "../dist"
+  },
+  "app": {
+    "windows": [
+      {
+        "title": "GFPS — Global Football Probability System",
+        "width": 1400,
+        "height": 900,
+        "resizable": true,
+        "decorations": true
+      }
+    ],
+    "security": {
+      "csp": null
+    }
+  }
+}

--- a/GFPS/desktop/tsconfig.json
+++ b/GFPS/desktop/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": ["app/*"],
+      "@components/*": ["components/*"],
+      "@screens/*": ["screens/*"],
+      "@charts/*": ["charts/*"],
+      "@api/*": ["api/*"],
+      "@hooks/*": ["hooks/*"],
+      "@store/*": ["store/*"],
+      "@theme/*": ["theme/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/GFPS/desktop/tsconfig.node.json
+++ b/GFPS/desktop/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/GFPS/desktop/vite.config.ts
+++ b/GFPS/desktop/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@app': path.resolve(__dirname, './src/app'),
+      '@components': path.resolve(__dirname, './src/components'),
+      '@screens': path.resolve(__dirname, './src/screens'),
+      '@charts': path.resolve(__dirname, './src/charts'),
+      '@api': path.resolve(__dirname, './src/api'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@store': path.resolve(__dirname, './src/store'),
+      '@theme': path.resolve(__dirname, './src/theme')
+    }
+  },
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- initialize GFPS desktop-only workspace with Tauri, Vite, React, and TypeScript configuration
- scaffold core UI screens (Dashboard, Live Match Center, Value Bets, Models & Training, Settings) with dark trading-style layout and navigation
- add API client, websocket hook, Zustand stores, and chart stubs to integrate with FastAPI backend

## Testing
- not run (desktop scaffold only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69416a6d0f70832485fa0fadf22a3b7a)