### PR TITLE
Clean roadmap API stubs and live state

### DIFF
--- a/backend/live_state.py
+++ b/backend/live_state.py
@@ -1,9 +1,9 @@
 """
 In-memory live state store for fixtures, events, and odds snapshots.
 
-This module offers a tiny publisher/subscriber mechanism used by the
-HTTP endpoints and the `/ws/live-matches` WebSocket to share the same
-snapshot data without requiring a real cache or database.
+This module offers a tiny publisher/subscriber mechanism used by the HTTP
+endpoints and the `/ws/live-matches` WebSocket to share the same snapshot data
+without requiring a real cache or database.
 """
 from __future__ import annotations
 
@@ -39,8 +39,6 @@ class LiveState:
         self.events: Dict[str, List[Dict[str, Any]]] = {}
         self.odds: List[Dict[str, Any]] = []
         self.market_lines: Dict[str, List[Dict[str, Any]]] = {}
-        self.events: List[Dict[str, Any]] = []
-        self.odds: List[Dict[str, Any]] = []
         self._subscribers: List[asyncio.Queue] = []
         self._lock = asyncio.Lock()
 
@@ -51,8 +49,6 @@ class LiveState:
             "odds": deepcopy(self.odds),
             "markets": deepcopy(self.market_lines),
         }
-        }
-        return {"fixtures": deepcopy(self.fixtures), "events": deepcopy(self.events)}
 
     async def subscribe(self) -> asyncio.Queue:
         q: asyncio.Queue = asyncio.Queue()
@@ -104,10 +100,6 @@ class LiveState:
             {"type": "event", "fixtureId": fixture_id, "event": deepcopy(event), **self.snapshot()}
         )
         await self._persist_snapshot("event")
-
-    async def add_event(self, event: Dict[str, Any]) -> None:
-        self.events.append(event)
-        await self.broadcast({"type": "event", "event": deepcopy(event), **self.snapshot()})
 
     async def tick_demo_clock(self) -> None:
         """Simulate a minimal live update for demo fixtures."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,6 @@
 """
 G.F.P.S – Global Football Probability System
 Backend API (FastAPI)
-
-Exposes:
-- Auth (local + Google + 2FA + reset)
-- Fixtures & markets
-- Coupon builder
-- Favorites
-- Devices (push tokens)
-- Stats
-- Alerts (rules + events)
-- Background engines (alerts + streamer)
 """
 
 import asyncio
@@ -20,83 +10,23 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .db import Base, engine
 from . import models  # noqa: F401  # ensure models are imported
-
+from .alert_engine import start_alert_engine_background
+from .alerts_api import router as alerts_router
+from .coupon_api import router as coupon_router
+from .device_api import router as device_router
+from .favorites_api import router as favorites_router
+from .fixtures_api import router as fixtures_router
 from .google_auth import router as auth_router
-from .fixtures_api import router as fixtures_router
-from .live_odds_api import router as live_odds_router
-from .live_ws import router as live_ws_router
-from .markets_api import router as markets_router
-from .coupon_api import router as coupon_router
-from .favorites_api import router as favorites_router
-from .device_api import router as device_router
-from .stats_api import router as stats_router
-from .alerts_api import router as alerts_router
-from .predictions_api import router as predictions_router
-from .value_bets_api import router as value_bets_router
-from .ml_api import router as ml_router
-from .alert_engine import start_alert_engine_background
-from .streamer import start_streamer_background
 from .health_api import router as health_router
+from .live_odds_api import router as live_odds_router
+from .live_ws import router as live_ws_router
+from .markets_api import router as markets_router
+from .ml_api import router as ml_router
+from .predictions_api import router as predictions_router
 from .snapshot_service import backfill_demo_if_empty, start_snapshot_scheduler
-from .fixtures_api import router as fixtures_router
-from .live_odds_api import router as live_odds_router
-from .live_ws import router as live_ws_router
-from .markets_api import router as markets_router
-from .coupon_api import router as coupon_router
-from .favorites_api import router as favorites_router
-from .device_api import router as device_router
 from .stats_api import router as stats_router
-from .alerts_api import router as alerts_router
-from .predictions_api import router as predictions_router
-from .value_bets_api import router as value_bets_router
-from .ml_api import router as ml_router
-from .alert_engine import start_alert_engine_background
 from .streamer import start_streamer_background
-from .health_api import router as health_router
-from .snapshot_service import backfill_demo_if_empty, start_snapshot_scheduler
-from .fixtures_api import router as fixtures_router
-from .live_odds_api import router as live_odds_router
-from .live_ws import router as live_ws_router
-from .markets_api import router as markets_router
-from .coupon_api import router as coupon_router
-from .favorites_api import router as favorites_router
-from .device_api import router as device_router
-from .stats_api import router as stats_router
-from .alerts_api import router as alerts_router
-from .predictions_api import router as predictions_router
 from .value_bets_api import router as value_bets_router
-from .ml_api import router as ml_router
-from .alert_engine import start_alert_engine_background
-from .streamer import start_streamer_background
-from .fixtures_api import router as fixtures_router
-from .live_odds_api import router as live_odds_router
-from .live_ws import router as live_ws_router
-from .markets_api import router as markets_router
-from .coupon_api import router as coupon_router
-from .favorites_api import router as favorites_router
-from .device_api import router as device_router
-from .stats_api import router as stats_router
-from .alerts_api import router as alerts_router
-from .predictions_api import router as predictions_router
-from .value_bets_api import router as value_bets_router
-from .ml_api import router as ml_router
-from .alert_engine import start_alert_engine_background
-from .streamer import start_streamer_background
-from .fixtures_api import router as fixtures_router
-from .live_odds_api import router as live_odds_router
-from .live_ws import router as live_ws_router
-from .markets_api import router as markets_router
-from .coupon_api import router as coupon_router
-from .favorites_api import router as favorites_router
-from .device_api import router as device_router
-from .stats_api import router as stats_router
-from .alerts_api import router as alerts_router
-from .predictions_api import router as predictions_router
-from .value_bets_api import router as value_bets_router
-from .ml_api import router as ml_router
-from .alert_engine import start_alert_engine_background
-from .streamer import start_streamer_background
-
 
 app = FastAPI(
     title="GFPS – Global Football Probability System",
@@ -132,17 +62,6 @@ async def startup_event() -> None:
     start_alert_engine_background(loop)
     start_streamer_background(loop)
     start_snapshot_scheduler(loop)
-    # Create all DB tables if they don't exist
-    Base.metadata.create_all(bind=engine)
-
-    # Ensure demo seeds are persisted for offline use
-    backfill_demo_if_empty()
-
-    # Start background workers (alerts + live streamer)
-    loop = asyncio.get_event_loop()
-    start_alert_engine_background(loop)
-    start_streamer_background(loop)
-    start_snapshot_scheduler(loop)
 
 
 # -------------------------------------------------------------------
@@ -156,87 +75,6 @@ app.include_router(predictions_router)
 app.include_router(value_bets_router)
 app.include_router(ml_router)
 app.include_router(health_router)
-app.include_router(markets_router)
-app.include_router(coupon_router)
-app.include_router(favorites_router)
-app.include_router(device_router)
-app.include_router(stats_router)
-app.include_router(alerts_router)
-
-
-# -------------------------------------------------------------------
-# Health / root
-# -------------------------------------------------------------------
-@app.get("/")
-async def root():
-app.include_router(auth_router)
-app.include_router(fixtures_router)
-app.include_router(live_odds_router)
-app.include_router(live_ws_router)
-app.include_router(predictions_router)
-app.include_router(value_bets_router)
-app.include_router(ml_router)
-app.include_router(health_router)
-app.include_router(markets_router)
-app.include_router(coupon_router)
-app.include_router(favorites_router)
-app.include_router(device_router)
-app.include_router(stats_router)
-app.include_router(alerts_router)
-
-
-# -------------------------------------------------------------------
-# Health / root
-# -------------------------------------------------------------------
-@app.get("/")
-async def root():
-app.include_router(auth_router)
-app.include_router(fixtures_router)
-app.include_router(live_odds_router)
-app.include_router(live_ws_router)
-app.include_router(predictions_router)
-app.include_router(value_bets_router)
-app.include_router(ml_router)
-app.include_router(markets_router)
-app.include_router(coupon_router)
-app.include_router(favorites_router)
-app.include_router(device_router)
-app.include_router(stats_router)
-app.include_router(alerts_router)
-
-
-# -------------------------------------------------------------------
-# Health / root
-# -------------------------------------------------------------------
-@app.get("/")
-async def root():
-app.include_router(auth_router)
-app.include_router(fixtures_router)
-app.include_router(live_odds_router)
-app.include_router(live_ws_router)
-app.include_router(predictions_router)
-app.include_router(value_bets_router)
-app.include_router(ml_router)
-app.include_router(markets_router)
-app.include_router(coupon_router)
-app.include_router(favorites_router)
-app.include_router(device_router)
-app.include_router(stats_router)
-app.include_router(alerts_router)
-
-
-# -------------------------------------------------------------------
-# Health / root
-# -------------------------------------------------------------------
-@app.get("/")
-async def root():
-app.include_router(auth_router)
-app.include_router(fixtures_router)
-app.include_router(live_odds_router)
-app.include_router(live_ws_router)
-app.include_router(predictions_router)
-app.include_router(value_bets_router)
-app.include_router(ml_router)
 app.include_router(markets_router)
 app.include_router(coupon_router)
 app.include_router(favorites_router)

--- a/backend/predictions_api.py
+++ b/backend/predictions_api.py
@@ -4,34 +4,15 @@ from fastapi import APIRouter, Depends
 
 from .auth_dependency import require_user
 from .live_state import live_state
-from .snapshot_service import latest_snapshot_payload
-from fastapi import APIRouter
-
-from .live_state import live_state
 from .prediction_engine import generate_predictions
+from .snapshot_service import latest_snapshot_payload
 
 router = APIRouter(prefix="/predictions", tags=["predictions"])
 
 
 @router.get("", dependencies=[Depends(require_user)])
-@router.get("")
 async def list_predictions() -> List[dict]:
-    """Return demo-friendly predictions aligned to the desktop type.
+    """Return predictions aligned to the desktop type."""
 
-    For now we generate simple probabilities from the current fixture snapshot.
-    """
     snapshot = latest_snapshot_payload() or live_state.snapshot()
     return generate_predictions(snapshot)
-    snapshot = live_state.snapshot()
-    return generate_predictions(snapshot)
-    predictions = []
-    for fx in snapshot["fixtures"]:
-        predictions.append(
-            {
-                "fixtureId": fx["id"],
-                "homeWinProbability": 0.45,
-                "drawProbability": 0.28,
-                "awayWinProbability": 0.27,
-            }
-        )
-    return predictions

--- a/backend/value_bets_api.py
+++ b/backend/value_bets_api.py
@@ -4,11 +4,8 @@ from fastapi import APIRouter, Depends
 
 from .auth_dependency import require_user
 from .live_state import live_state
-from .snapshot_service import latest_snapshot_payload
-from fastapi import APIRouter
-
-from .live_state import live_state
 from .prediction_engine import compute_value_bets
+from .snapshot_service import latest_snapshot_payload
 
 router = APIRouter(prefix="/value-bets", tags=["value-bets"])
 
@@ -16,29 +13,6 @@ router = APIRouter(prefix="/value-bets", tags=["value-bets"])
 @router.get("", dependencies=[Depends(require_user)])
 async def list_value_bets() -> List[dict]:
     """Return simplified value bet rows expected by the desktop client."""
+
     snapshot = latest_snapshot_payload() or live_state.snapshot()
     return compute_value_bets(snapshot)
-@router.get("")
-async def list_value_bets() -> List[dict]:
-    """Return simplified value bet rows expected by the desktop client."""
-    snapshot = live_state.snapshot()
-    return compute_value_bets(snapshot)
-
-    bets: List[dict] = []
-    snapshot = live_state.snapshot()
-    for fx in snapshot["fixtures"]:
-        match_label = f"{fx['homeTeam']} vs {fx['awayTeam']}"
-        # Demo model probability and odds
-        model_prob = 0.55
-        odds = 2.2
-        expected_value = model_prob * odds - 1
-        bets.append(
-            {
-                "match": match_label,
-                "market": "Match Winner - Home",
-                "odds": odds,
-                "modelProbability": model_prob,
-                "expectedValue": round(expected_value, 2),
-            }
-        )
-    return bets


### PR DESCRIPTION
## Summary
- deduplicate FastAPI startup wiring and prediction/value bet endpoints to align with desktop expectations
- rebuild live odds API and in-memory live state to remove duplicate code and support markets/odds snapshots
- streamline ML API to rely on persisted model records and background training runs

## Testing
- python -m compileall backend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a64a0d6c8324b75a4e99bc76d49e)